### PR TITLE
Fix demo aspect ratio of gif in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > [Alfred](https://alfredapp.com) workflow to toggle the system dark mode
 
-<img src="screenshot.gif" width="696" height="280">
+<img src="screenshot.gif" width="696">
 
 ## Install
 


### PR DESCRIPTION
Current readme:

<img width="486" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/219309205-4b65b626-8768-42be-8a9e-8305ce4add43.png">
